### PR TITLE
Moved dynamic-rules url to config.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -33,6 +33,9 @@ $PWD/ofdl.yaml. The following is a comprehensive example configuration file:
   	# Path to Chromium profile directory
   	profile: ~/.config/chromium/Default
   
+  # The URL to use for downloading the latest set of dynamic rule
+  dynamic-rules-url: https://github.com/DIGITALCRIMINALS/dynamic-rules/raw/main/onlyfans.json
+  
   # Authentication Config
   auth:
   	cookie:

--- a/ofdl.example.yaml
+++ b/ofdl.example.yaml
@@ -10,3 +10,4 @@ downloads:
 chromium:
     exec: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
     profile: ~/Library/Application Support/Google/Chrome/Default
+dynamic-rules-url: https://github.com/DIGITALCRIMINALS/dynamic-rules/raw/main/onlyfans.json

--- a/ofdl/onlyfans/dynamic_rules.go
+++ b/ofdl/onlyfans/dynamic_rules.go
@@ -11,7 +11,9 @@ func NewDynamicRules() (*viper.Viper, error) {
 	v := viper.New()
 	v.SetConfigType("json")
 
-	r, err := http.Get("https://github.com/DIGITALCRIMINALS/dynamic-rules/raw/main/onlyfans.json")
+	url := viper.GetString("dynamic-rules-url")
+
+	r, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The hardcode dynamic rules url can become out of date over time, so moved it to the config to let it be changed without needing to recompile from source.

(As mentioned in https://github.com/ofdl/ofdl/issues/5)